### PR TITLE
fix GSLB monitor hash key

### DIFF
--- a/dyn/tm/services/gslb.py
+++ b/dyn/tm/services/gslb.py
@@ -904,7 +904,7 @@ class GSLB(object):
         # We're only going accept new monitors of type Monitor
         if isinstance(value, Monitor):
             self._monitor = value
-            api_args = {'performance_monitor':
+            api_args = {'monitor':
                         self._monitor.to_json()}
             response = DynectSession.get_session().execute(self.uri, 'PUT',
                                                            api_args)


### PR DESCRIPTION
Attempting to change the monitor for a GSLB fails silently. According to the [API documentation](https://help.dyn.com/update-gslb-service-api/), the correct hash key is monitor, not performance_monitor. After making this change, I can update the monitor for a GSLB instance.
