### PR TITLE
fix for python bug?

### DIFF
--- a/dyn/__init__.py
+++ b/dyn/__init__.py
@@ -5,7 +5,7 @@ services.
 
 Requires Python 2.6 or higher, or the "simplejson" package.
 """
-version_info = (1, 3, 4)
+version_info = (1, 3, 5)
 __name__       = 'dyn'
 __doc__        = 'A python wrapper for the DynDNS and DynEmail APIs'
 __author__     = 'Jonathan Nappi, Cole Tuininga'

--- a/dyn/mm/utils.py
+++ b/dyn/mm/utils.py
@@ -2,15 +2,17 @@
 """Utilities for use across the Message Manamgent module"""
 from datetime import datetime
 
-API_FMT = '%Y-%m-%dT%H:%M:%S%z'
+
+API_FMT = '%Y-%m-%dT%H:%M:%S'
 
 
 def str_to_date(date_string):
     """Convert a Message Manamgent API formatted string into a standard python
-    ``datetime.datetime`` object.
+    ``datetime.datetime`` object.  Note that this object's tzinfo will
+    not be set, in other words time zone is ignored.
     """
-    if date_string[-3] == ':':
-        date_string = date_string[:-3] + date_string[-2:]
+    if date_string[-6:] == '+00:00':
+        date_string = date_string[:-6]
     return datetime.strptime(date_string, API_FMT)
 
 
@@ -19,8 +21,6 @@ def date_to_str(date_obj):
     Management API formatted string
     """
     date_string = date_obj.strftime(API_FMT)
-    if date_string[-3] != ':':
-        date_string = date_string[:-2] + ':' + date_string[-2:]
     return date_string
 
 


### PR DESCRIPTION
When I run this:

``` python
from dyn.mm.accounts import get_all_suppressions
# where startdate & enddate are datetime.datetime objects without tzinfo set:
get_all_suppressions(startdate, enddate, startindex=whatever)
```

I get an obscure error; the traceback goes into the files I changed, but here's the kind of exceptions I'd get:  `ValueError: 'z' is a bad directive in format '%Y-%m-%dT%H:%M:%S%z'`.  This seems to be because python 2.7 doesn't support %z in datetime.datetime.strptime:

http://bugs.python.org/issue6641

This is fixed in python 3.2 apparently, but people running python 2.7 will probably want this.

I don't _think_ I damaged anything since the API calls I'm making seem to use both of the utility functions I changed.
