### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ install:
 - pip install -r test-requirements.txt --use-mirrors
 - pip install coveralls --use-mirrors
 before_script:
-- mkdir -p log
+- mkdir tests
 script:
 - tox
-after_script:
-- rm -rf log
 after_success:
 - coveralls
 branches:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     -rtest-requirements.txt
 
 commands =
-    /bin/mkdir -p log
     py.test -q --basetemp={envtmpdir} --confcutdir=.. -n 1 \
         --junitxml=tests/junit.xml \
         --cov-report xml --cov dyn \


### PR DESCRIPTION
travis build was failing on my end : https://travis-ci.org/steenzout/dyn-python/builds/46005750

it's now building correctly : https://travis-ci.org/steenzout/dyn-python/requests

no need to create log directory but tests should be present so pytest could write the junit.xml file.
