### PR TITLE
keep fqdn from the api response when fetching all records

### DIFF
--- a/dyn/tm/zones.py
+++ b/dyn/tm/zones.py
@@ -422,13 +422,13 @@ class Zone(object):
             list_records = []
             for record in record_list:
                 del record['zone']
+                fqdn = record['fqdn']
                 del record['fqdn']
                 # Unpack rdata
                 for r_key, r_val in record['rdata'].items():
                     record[r_key] = r_val
                 record['create'] = False
-                list_records.append(constructor(self._name, self.fqdn,
-                                                **record))
+                list_records.append(constructor(self._name, fqdn, **record))
             records[key] = list_records
         return records
 
@@ -458,6 +458,7 @@ class Zone(object):
         response = DynectSession.get_session().execute(uri, 'GET', api_args)
         records = []
         for record in response['data']:
+            fqdn = record['fqdn']
             del record['fqdn']
             del record['zone']
             # Unpack rdata
@@ -465,7 +466,7 @@ class Zone(object):
                 record[key] = val
             del record['rdata']
             record['create'] = False
-            records.append(constructor(self._name, self.fqdn, **record))
+            records.append(constructor(self._name, fqdn, **record))
         return records
 
     def get_any_records(self):


### PR DESCRIPTION
I suspect that we might just be doing it wrong, but a colleague pointed out the following behavior when querying a zone with two A records (for example, notoptimal.com and www.notoptimal.com) ...
```
>>> from dyn.tm.zones import Zone
# session establishment
>>> z = Zone('notoptimal.com')
>>> [a.fqdn for a in z.get_all_records()['a_records']]
['notoptimal.com.', 'notoptimal.com.']
```
... which does not appear to jibe with the documentation for the various DNSRecord subclasses. 

> zone – Name of **zone** where the record will be added
> fqdn – Name of **node** where the record will be added

We were expecting that fqdn would contain the node + zone, instead of just the zone. After this patch, the output of the above code is as follows ...
```
[u'notoptimal.com', u'www.notoptimal.com']
```
... and besides the Unicode difference, this is the result we expect.

Have we stumbled upon a bug, or did we just misunderstand the docs?

If this PR is useful after review, it's probably worth noting that the `Node` class has similar methods, `get_all_records` and `get_all_records_by_type`, currently unchanged by this pull request. I left them alone since they don't interfere with our particular use case, but the `Node` class, in particular, may need further attention. 

Advice about where to include unit tests, if desirable, would be greatly appreciated.