### PR TITLE
add proxy capability

### DIFF
--- a/dyn/mm/session.py
+++ b/dyn/mm/session.py
@@ -19,7 +19,8 @@ class MMSession(SessionEngine):
     _valid_methods = ('GET', 'POST')
     uri_root = '/rest/json'
 
-    def __init__(self, apikey, host='emailapi.dynect.net', port=443, ssl=True):
+    def __init__(self, apikey, host='emailapi.dynect.net', port=443, ssl=True,
+                 proxy_host=None, proxy_port=None, proxy_user=None, proxy_pass=None):
         """Initialize a Dynect Rest Session object and store the provided
         credentials
 
@@ -27,8 +28,13 @@ class MMSession(SessionEngine):
         :param port: Port to connect to DynECT API server
         :param ssl: Enable SSL
         :param apikey: your unique Email API key
+        :param proxy_host: A proxy host to utilize
+        :param proxy_port: The port that the proxy is served on
+        :param proxy_user: A username to connect to the proxy with if required
+        :param proxy_pass: A password to connect to the proxy with if required
         """
-        super(MMSession, self).__init__(host, port, ssl)
+        super(MMSession, self).__init__(host, port, ssl, proxy_host, proxy_port,
+                                        proxy_user, proxy_pass)
         self.apikey = apikey
         self.content_type = 'application/x-www-form-urlencoded'
         self._conn = None

--- a/dyn/tm/session.py
+++ b/dyn/tm/session.py
@@ -19,7 +19,8 @@ class DynectSession(SessionEngine):
 
     def __init__(self, customer, username, password, host='api.dynect.net', 
                  port=443, ssl=True, api_version='current', auto_auth=True,
-                 key=None, history=False):
+                 key=None, history=False, proxy_host=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None):
         """Initialize a Dynect Rest Session object and store the provided
         credentials
 
@@ -35,8 +36,14 @@ class DynectSession(SessionEngine):
             encrypting your password
         :param history: A boolean flag determining whether or not you would
             like to store a record of all API calls made to review later
+        :param proxy_host: A proxy host to utilize
+        :param proxy_port: The port that the proxy is served on
+        :param proxy_user: A username to connect to the proxy with if required
+        :param proxy_pass: A password to connect to the proxy with if required
         """
-        super(DynectSession, self).__init__(host, port, ssl, history)
+        super(DynectSession, self).__init__(host, port, ssl, history,
+                                            proxy_host, proxy_port,
+                                            proxy_user, proxy_pass)
         self.__cipher = AESCipher(key)
         self.extra_headers = {'API-Version': api_version}
         self.customer = customer


### PR DESCRIPTION
This adds proxy capability to the connection logic.  It is backwards compatible.  It works with proxies that require authentication and ones that do not.

Attempted running `tox` but there were endless PEP8 errors that are unrelated to this change.

Local testing:
```
$ python setup.py install
>>> from dyn.tm.session import DynectSession
>>> s = DynectSession('company', 'user', 'pass', history=True)
>>> s.history
[('2016-03-18T00:05:37.941333', '/REST/Session/', 'POST', {'password': '*****', 'user_name': 'user', 'customer_name': 'company'}, u'success')]
>>> s = DynectSession.new_session('company', 'user', 'pass', history=True, proxy_host='localhost', proxy_port=8888)
>>> s.history
[('2016-03-18T00:06:30.882102', '/REST/Session/', 'POST', {'password': '*****', 'user_name': 'user', 'customer_name': 'customer'}, u'success')]
>>> s = DynectSession.new_session('company', 'user', 'pass', history=True, proxy_host='localhost', proxy_port=8888, proxy_user='user', proxy_pass='pass')
>>> s.history
[('2016-03-18T00:07:44.728913', '/REST/Session/', 'POST', {'password': '*****', 'user_name': 'user', 'customer_name': 'company'}, u'success')]
```
