### PR TITLE
Don't renew token for connection reset

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,8 @@
 Release History
 ---------------
+1.7.5 (2016-09-09)
+++++++++++++++++++
+*Bug fix for token renewal on connection timeout
 
 1.7.4 (2016-08-30)
 ++++++++++++++++++

--- a/dyn/__init__.py
+++ b/dyn/__init__.py
@@ -5,7 +5,7 @@ services.
 
 Requires Python 2.6 or higher, or the "simplejson" package.
 """
-version_info = (1, 7, 4)
+version_info = (1, 7, 5)
 __name__ = 'dyn'
 __doc__ = 'A python wrapper for the DynDNS and DynEmail APIs'
 __author__ = 'Jonathan Nappi, Cole Tuininga, Marc Howes, Philip Andrews'

--- a/dyn/compat.py
+++ b/dyn/compat.py
@@ -31,7 +31,7 @@ if is_py2:
             import simplejson as json
         except ImportError:
             raise ex
-    from httplib import HTTPConnection, HTTPSConnection, HTTPException
+    from httplib import HTTPConnection, HTTPSConnection, HTTPException, BadStatusLine
     from urllib import urlencode, pathname2url
 
     string_types = (str, unicode)  # NOQA
@@ -73,7 +73,7 @@ if is_py2:
 
 elif is_py3:
     from http.client import (HTTPConnection, HTTPSConnection,  # NOQA
-                             HTTPException)  # NOQA
+                             HTTPException, BadStatusLine)  # NOQA
     from urllib.parse import urlencode  # NOQA
     from urllib.request import pathname2url  # NOQA
     import json  # NOQA

--- a/dyn/compat.py
+++ b/dyn/compat.py
@@ -31,7 +31,8 @@ if is_py2:
             import simplejson as json
         except ImportError:
             raise ex
-    from httplib import HTTPConnection, HTTPSConnection, HTTPException, BadStatusLine
+    from httplib import (HTTPConnection, HTTPSConnection,
+                         HTTPException, BadStatusLine)
     from urllib import urlencode, pathname2url
 
     string_types = (str, unicode)  # NOQA

--- a/dyn/tm/session.py
+++ b/dyn/tm/session.py
@@ -215,15 +215,19 @@ class DynectMultiSession(DynectSession):
                                                  proxy_pass=proxy_pass)
         self.__add_open_session()
 
-    def _handle_error(self, uri, method, raw_args):
+    def _handle_error(self, uri, method, raw_args, renew_token=True):
         """Handle the processing of a connection error with the api"""
-        # Our token is no longer valid because our session was killed
-        self._token = None
+
         # Need to force a re-connect on next execute
         self._conn.close()
         self._conn.connect()
-        # Need to get a new Session token and update the open session
-        self.authenticate()
+
+        if renew_token:
+            # Our token is no longer valid because our session was killed
+            self._token = None
+            # Need to get a new Session token and update the open session
+            self.authenticate()
+
         # Then try the current call again and Specify final as true so
         # if we fail again we can raise the actual error
         return self.execute(uri, method, raw_args, final=True)

--- a/dyn/tm/session.py
+++ b/dyn/tm/session.py
@@ -72,15 +72,18 @@ class DynectSession(SessionEngine):
         """Accessible method for subclass to encrypt with existing AESCipher"""
         return self.__cipher.encrypt(data)
 
-    def _handle_error(self, uri, method, raw_args):
+    def _handle_error(self, uri, method, raw_args, renew_token=True):
         """Handle the processing of a connection error with the api"""
-        # Our token is no longer valid because our session was killed
-        self._token = None
         # Need to force a re-connect on next execute
         self._conn.close()
         self._conn.connect()
-        # Need to get a new Session token
-        self.execute('/REST/Session/', 'POST', self.__auth_data)
+
+        if renew_token:
+            # Our token is no longer valid because our session was killed
+            self._token = None
+            # Need to get a new Session token
+            self.execute('/REST/Session/', 'POST', self.__auth_data)
+
         # Then try the current call again and Specify final as true so
         # if we fail again we can raise the actual error
         return self.execute(uri, method, raw_args, final=True)


### PR DESCRIPTION
When the HTTP Connection times out/is closed, the connection is closed and re-opened by the SDK. We do not want the API token to be renewed when this occurs as pending changes created with the original token won't be published with the new token.