### PR TITLE
External nameserver bug fix

### DIFF
--- a/dyn/tm/zones.py
+++ b/dyn/tm/zones.py
@@ -1292,8 +1292,7 @@ class ExternalNameserver(object):
         :class:`ExternalNameserver` hosts. list of ExternalNameserverEntries
         """
         self._get()
-        return [ExternalNameserverEntry(host['address'], host['notifies'])
-                for host in self._hosts]
+        return [ExternalNameserverEntry(host.address, host.notifies) for host in self._hosts]
 
     @hosts.setter
     def hosts(self, value):
@@ -1346,16 +1345,14 @@ class ExternalNameserverEntry(object):
 
         """
         self._address = address
-        self._notifies = kwargs.get('notifies', None)
+        self._notifies = kwargs.get('notifies', 'N')
 
     @property
     def _json(self):
         """Get the JSON representation of this :class:`ExternalNameserverEntry`
         object
         """
-        json_blob = {'address': self._address,
-                     'notifies': self._notifies,
-                     }
+        json_blob = {'address': self._address, 'notifies': self._notifies}
         return {x: json_blob[x] for x in json_blob if json_blob[x] is not None}
 
     @property

--- a/dyn/tm/zones.py
+++ b/dyn/tm/zones.py
@@ -1292,7 +1292,7 @@ class ExternalNameserver(object):
         :class:`ExternalNameserver` hosts. list of ExternalNameserverEntries
         """
         self._get()
-        return [ExternalNameserverEntry(host.address, host.notifies) for host in self._hosts]
+        return self._hosts
 
     @hosts.setter
     def hosts(self, value):
@@ -1345,15 +1345,15 @@ class ExternalNameserverEntry(object):
 
         """
         self._address = address
-        self._notifies = kwargs.get('notifies', 'N')
+        self._notifies = kwargs.get('notifies')
 
     @property
     def _json(self):
         """Get the JSON representation of this :class:`ExternalNameserverEntry`
         object
         """
-        json_blob = {'address': self._address, 'notifies': self._notifies}
-        return {x: json_blob[x] for x in json_blob if json_blob[x] is not None}
+        json_blob = {'address': self._address, 'notifies': self._notifies }
+        return {k: v for k, v in json_blob.items() if v is not None}
 
     @property
     def address(self):


### PR DESCRIPTION
Currently `_hosts` is not repopulated when nameserver entries are modified; instead the list is generated dynamically from (now) stale data.  This change simply uses the `_hosts` attribute to retain entry state. 

Additionally, minor nitpick tweaks.
