### PR TITLE
retrieve the Monitor object in the GSLB._build() method

### DIFF
--- a/dyn/tm/services/gslb.py
+++ b/dyn/tm/services/gslb.py
@@ -811,8 +811,12 @@ class GSLB(object):
                         region_code = region.pop('region_code', None)
                         self._region.append(GSLBRegion(self._zone, self._fqdn,
                                                        region_code, **region))
+            elif key == 'monitor' and not val:
+                self._monitor = None
             elif key == 'monitor':
-                # We already have the monitor object, no need to rebuild it
+                self._monitor = Monitor(protocol=val['protocol'], interval=val['interval'])
+                for attr, v in val.items():
+                  setattr(self._monitor, '_'+attr, v)
                 pass
             elif key == "task_id" and not val:
                 self._task_id = None


### PR DESCRIPTION
The monitor attribute is always None when getting GSLB objects, for example when retrieved with Zone.get_all_gslb().
This patch allows the Monitor object to be instantiated inside the GSLB _build() method.