### PR TITLE
Raise ValueError on invalid response body

### DIFF
--- a/dyn/core.py
+++ b/dyn/core.py
@@ -11,7 +11,6 @@ import logging
 import re
 import threading
 import time
-import sys
 from datetime import datetime
 
 from . import __version__

--- a/dyn/core.py
+++ b/dyn/core.py
@@ -11,6 +11,7 @@ import logging
 import re
 import threading
 import time
+import sys
 from datetime import datetime
 
 from . import __version__
@@ -294,7 +295,13 @@ class SessionEngine(Singleton):
             self.logger.error(error_message)
             raise ValueError(error_message)
 
-        ret_val = json.loads(body.decode('UTF-8'))
+        json_err_fmt = "Decode Error on Response Body: {!r} status: {!r} {!r}"
+        try:
+            ret_val = json.loads(body.decode('UTF-8'))
+        except ValueError:
+            logging.error(json_err_fmt.format(body, response.status, uri))
+            raise
+
         if self.__call_cache is not None:
             self.__call_cache.append((uri, method, clean_args(raw_args),
                                       ret_val['status']))

--- a/dyn/core.py
+++ b/dyn/core.py
@@ -287,6 +287,13 @@ class SessionEngine(Singleton):
         if self.poll_incomplete:
             response, body = self.poll_response(response, body)
             self._last_response = response
+
+        if not body:
+            err_msg_fmt = "Received Empty Response: {!r} status: {!r} {!r}"
+            error_message = err_msg_fmt.format(body, response.status, uri)
+            self.logger.error(error_message)
+            raise ValueError(error_message)
+
         ret_val = json.loads(body.decode('UTF-8'))
         if self.__call_cache is not None:
             self.__call_cache.append((uri, method, clean_args(raw_args),

--- a/dyn/core.py
+++ b/dyn/core.py
@@ -298,7 +298,7 @@ class SessionEngine(Singleton):
         try:
             ret_val = json.loads(body.decode('UTF-8'))
         except ValueError:
-            logging.error(json_err_fmt.format(body, response.status, uri))
+            self.logger.error(json_err_fmt.format(body, response.status, uri))
             raise
 
         if self.__call_cache is not None:


### PR DESCRIPTION
Add error message and exception on empty `body` before `json.loads()` and catch `json.loads()` exception for invalid body.