### PR TITLE
Adding `get_dsf` to dsf.py

### DIFF
--- a/dyn/tm/services/dsf.py
+++ b/dyn/tm/services/dsf.py
@@ -35,6 +35,19 @@ __all__ = ['get_all_dsf_services', 'get_all_record_sets',
            'TrafficDirector']
 
 
+def get_dsf(service):
+    """
+    :param service: a dsf_id string, or :class:`TrafficDirector`
+    :return: :class:`TrafficDirector` Service
+    """
+    _service_id = _check_type(service)
+    uri = '/DSF/{}'.format(_service_id)
+    api_args = {'detail': 'Y'}
+    response = DynectSession.get_session().execute(uri, 'GET', api_args)
+    director = TrafficDirector(None, api=False, **response['data'])
+    return director
+
+
 def get_all_dsf_services():
     """:return: A ``list`` of :class:`TrafficDirector` Services"""
     uri = '/DSF/'


### PR DESCRIPTION
Adding a function that enables retrieving all config details for a single Traffic Director.

Relevant Dyn REST API documentation: https://help.dyn.com/get-dsf-api/

> Get One Traffic Director (DSF) instance — https://api.dynect.net/REST/DSF/<service_id>/