### PR TITLE
Fix syntax warning

### DIFF
--- a/dyn/core.py
+++ b/dyn/core.py
@@ -478,7 +478,7 @@ class SessionEngine(Singleton):
         now = datetime.now()
         self.logger.warn('Waiting for job {}'.format(job_id))
         too_long = (now - start).seconds < timeout
-        while response['status'] is 'incomplete' and too_long:
+        while response['status'] == 'incomplete' and too_long:
             time.sleep(10)
             response = self.execute(uri, 'GET', api_args)
         return response

--- a/dyn/tm/accounts.py
+++ b/dyn/tm/accounts.py
@@ -964,7 +964,7 @@ class PermissionsGroup(object):
         for key, val in self.__dict__.items():
             if val is not None and not hasattr(val, '__call__') and \
                     key.startswith('_'):
-                if key is '_group_type':
+                if key == '_group_type':
                     api_args['type'] = val
                 else:
                     api_args[key[1:]] = val


### PR DESCRIPTION
On python 3.9 ...

```
[...]/dyn-1.8.1-py3.9.egg/dyn/core.py:481: SyntaxWarning: "is" with a literal. Did you mean "=="?
[...]/dyn-1.8.1-py3.9.egg/dyn/core.py:481: SyntaxWarning: "is" with a literal. Did you mean "=="?
[...]/dyn-1.8.1-py3.9.egg/dyn/tm/accounts.py:967: SyntaxWarning: "is" with a literal. Did you mean "=="?
[...]/dyn-1.8.1-py3.9.egg/dyn/tm/accounts.py:967: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

This warning was [introduced](https://bugs.python.org/issue34850) in python 3.8. `ìs` tests for identity and `==` tests for equality so in these two instances it is more appropriate to use `==`


