### PR TITLE
Fix Python 3.10 compatibility (collections.abc imports)

### DIFF
--- a/dyn/tm/services/dsf.py
+++ b/dyn/tm/services/dsf.py
@@ -2,7 +2,7 @@
 """This module contains wrappers for interfacing with every element of a
 Traffic Director (DSF) service.
 """
-from collections import Iterable
+from collections.abc import Iterable
 from dyn.compat import force_unicode, string_types
 from dyn.tm.utils import APIList, Active
 from dyn.tm.errors import DynectInvalidArgumentError


### PR DESCRIPTION
Many classes moved from `collections` module to `collections.abc`.

https://docs.python.org/3.9/library/collections.html?highlight=collections#module-collections

> Deprecated since version 3.3, will be removed in version 3.10: Moved
> Collections Abstract Base Classes to the collections.abc module. For
> backwards compatibility, they continue to be visible in this module
> through Python 3.9.