### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/dyn/__init__.py
+++ b/dyn/__init__.py
@@ -5,7 +5,7 @@ services.
 
 Requires Python 2.6 or higher, or the "simplejson" package.
 """
-version_info = (1, 8, 3)
+version_info = (1, 8, 4)
 __name__ = 'dyn'
 __doc__ = 'A python wrapper for the DynDNS and DynEmail APIs'
 __author__ = '''

--- a/dyn/tm/services/dsf.py
+++ b/dyn/tm/services/dsf.py
@@ -2,7 +2,10 @@
 """This module contains wrappers for interfacing with every element of a
 Traffic Director (DSF) service.
 """
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from dyn.compat import force_unicode, string_types
 from dyn.tm.utils import APIList, Active
 from dyn.tm.errors import DynectInvalidArgumentError


### PR DESCRIPTION
Also maintain compatibility with 2.7, and increment the version.